### PR TITLE
Fast fix to circumvent "immutable" error when json-pickling the model

### DIFF
--- a/src/engine/server/__init__.py
+++ b/src/engine/server/__init__.py
@@ -13,7 +13,7 @@ from server.services.global_store import GlobalStore
 
 os.environ["WERKZEUG_RUN_MAIN"] = "true"
 MODEL_LOAD_LIMIT = 1
-CACHE_OPTION = True
+CACHE_OPTION = False
 EPSILON_MULTIPLIER = 0.001
 IDLE_MINUTES = 60 * 5
 try:


### PR DESCRIPTION
Temporarily disable cache so that the model will not be json-serialized.